### PR TITLE
Fix the RTC fallthrough when setting IRQ.

### DIFF
--- a/src/main/java/gamax92/thistle/devices/RTC.java
+++ b/src/main/java/gamax92/thistle/devices/RTC.java
@@ -133,8 +133,10 @@ public class RTC extends Device {
 			break;
 		case RTC_IRQMASK_REG:
 			irqmask = data;
+			break;
 		case RTC_NMIMASK_REG:
 			nmimask = data;
+			break;
 		}
 	}
 


### PR DESCRIPTION
This fixes the old problem I noticed with timers causing an NMI instead of an IRQ, there was a (unintentional, I assume) fallthrough from RTC_IRQMASK_REG to RTC_NMIMASK_REG -- causing both to be set if IRQMASK was.