### PR TITLE
Fix OC dependency line for 1.12

### DIFF
--- a/src/main/java/gamax92/thistle/Thistle.java
+++ b/src/main/java/gamax92/thistle/Thistle.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = Thistle.MODID, name = Thistle.NAME, version = Thistle.VERSION, dependencies = "required-after:OpenComputers@[1.6.0,)")
+@Mod(modid = Thistle.MODID, name = Thistle.NAME, version = Thistle.VERSION, dependencies = "required-after:opencomputers@[1.7.0,)")
 public class Thistle {
 	public static final String MODID = "thistle";
 	public static final String NAME = "Thistle Computer";


### PR DESCRIPTION
Just tested it with OC 1.7.4.153 on MC 1.12.2, and the mod seems to work perfectly fine with this tweak (forge demands modids to be lowercase) :+1: 